### PR TITLE
Update unstructured grid page examples, add them to test suite

### DIFF
--- a/cfplot/test/test_examples.py
+++ b/cfplot/test/test_examples.py
@@ -1323,6 +1323,30 @@ class ExamplesTest(unittest.TestCase):
     # https://ncas-cms.github.io/cf-plot/build/unstructured.html#unstructured)
 
 
+class UnnumberedExamplesTest(unittest.TestCase):
+    """Run all other documentation examples and compare to reference plots."""
+
+    data_dir = DATA_DIR
+    save_gen_dir = TEST_GEN_DIR
+    ref_dir = TEST_REF_DIR
+    test_id = None
+
+    def setUp(self):
+        """Preparations called immediately before each test method."""
+        # Get a filename fname with the ID of test_example_X component X
+        test_method_name = unittest.TestCase.id(self).split(".")[-1]
+        self.test_id = test_method_name.rsplit("test_example_")[1]
+        fname = f"{self.save_gen_dir}/" f"gen_fig_{self.test_id}.png"
+        cfp.setvars(
+            file=fname,
+            viewer="matplotlib",
+        )
+
+    def tearDown(self):
+        """Preparations called immediately after each test method."""
+        cfp.reset()
+
+
 if __name__ == "__main__":
     print("==================\n" "Regression testing\n" "==================\n")
     cov = coverage.Coverage()

--- a/cfplot/test/test_examples.py
+++ b/cfplot/test/test_examples.py
@@ -21,6 +21,8 @@ from scipy.interpolate import griddata
 
 import matplotlib.testing.compare as mpl_compare
 
+import cartopy.crs as ccrs
+
 import cfplot as cfp
 import cf
 
@@ -1345,6 +1347,117 @@ class UnnumberedExamplesTest(unittest.TestCase):
     def tearDown(self):
         """Preparations called immediately after each test method."""
         cfp.reset()
+
+    # @compare_plot_results  # SLB TODO add expected plot
+    def test_example_unstructured_lfric_1(self):
+        """Test example for unstructured grids: LFRic example 1."""
+        f = cf.read("cfplot_data/lfric_initial.nc")
+
+        # Select the relevant fields for the objects required for the plot,
+        # taking the air potential temperature as a variable to choose to view.
+        pot = f.select_by_identity("air_potential_temperature")[0]
+        lats = f.select_by_identity("latitude")[0]
+        lons = f.select_by_identity("longitude")[0]
+        faces = f.select_by_identity("cf_role=face_edge_connectivity")[0]
+
+        # Reduce the variable to match the shapes
+        pot = pot[4,:]
+
+        cfp.levs(240, 310, 5)
+
+        cfp.con(
+            f=pot, face_lons=lons, face_lats=lats,
+            face_connectivity=faces, lines=False
+        )
+
+    # @compare_plot_results  # SLB TODO add expected plot
+    def test_example_unstructured_lfric_2(self):
+        """Test example for unstructured grids: LFRic example 2."""
+        f = cf.read("cfplot_data/lfric_initial.nc")
+
+        # Select the relevant fields for the objects required for the plot,
+        # taking the air potential temperature as a variable to choose to view.
+        pot = f.select_by_identity("air_potential_temperature")[0]
+        lats = f.select_by_identity("latitude")[0]
+        lons = f.select_by_identity("longitude")[0]
+        faces = f.select_by_identity("cf_role=face_edge_connectivity")[0]
+
+        # Reduce the variable to match the shapes
+        pot = pot[4,:]
+
+        cfp.levs(240, 310, 5)
+
+        # This time set the projection to a polar one for a different view
+        cfp.mapset(proj="npstere")
+        cfp.con(
+            f=pot, face_lons=lons,
+            face_lats=lats, face_connectivity=faces, lines=False
+        )
+
+    # @compare_plot_results  # SLB TODO add expected plot
+    def test_example_unstructured_lfric_3(self):
+        """Test example for unstructured grids: LFRic example 3."""
+        f = cf.read("cfplot_data/lfric_initial.nc")
+        pot = f.select_by_identity("air_potential_temperature")[0]
+
+        g = pot[0, :]
+        cfp.con(g, lines=False)
+
+    @unittest.expectedFailure  # suspected cf-plot bug, needs investigating
+    def test_example_unstructured_orca_1(self):
+        """Test example for unstructured grids: ORCA grid example 1."""
+        # NOTE: this is taken from the 'unstructured.rst/html' page, but
+        # is very similar to 'test_example_26', so coordinate with that.
+        f = cf.read("cfplot_data/orca2.nc")
+
+        # Get an Orca grid and flatten the arrays
+        lons = f.select_by_identity("ncvar%longitude")[0]
+        lats = f.select_by_identity("ncvar%latitude")[0]
+        temp = f.select_by_identity("ncvar%sst")[0]
+
+        lons.flatten(inplace=True)
+        lats.flatten(inplace=True)
+        temp.flatten(inplace=True)
+
+        cfp.con(x=lons, y=lats, f=temp, ptype=1)
+
+    @unittest.expectedFailure  # text input based, needs investigating
+    def test_example_unstructured_station_data_1(self):
+        """Test example for unstructured grids: station data example 1."""
+        # NOTE: this is taken from the 'unstructured.rst/html' page, but
+        # is very similar to 'test_example_24/25', so coordinate with that.
+
+        # Part 1: docs title 'Station data'
+
+        # Arrays for data
+        lons=[]
+        lats=[]
+        pressure=[]
+        temp=[]
+
+        # Read data and make the contour plot
+        f = open('cfplot_data/synop_data.txt')
+        lines = f.readlines()
+        for line in lines:
+           mysplit=line.split()
+           lons=np.append(lons, float(mysplit[1]))
+           lats=np.append(lats, float(mysplit[2]))
+           pressure=np.append(pressure, float(mysplit[3]))
+           temp=np.append(temp, float(mysplit[4]))
+
+        cfp.con(
+            x=lons, y=lats, f=temp, ptype=1, colorbar_orientation='vertical')
+
+        # Part 2: docs title 'Station data - check of data values'
+        cfp.gopen()
+        for i in np.arange(len(lines)):
+            cfp.plotvars.mymap.text(
+                float(lons[i]), float(lats[i]), str(temp[i]),
+                horizontalalignment='center',verticalalignment='center',
+                transform=ccrs.PlateCarree()
+            )
+
+        cfp.gclose()
 
 
 if __name__ == "__main__":

--- a/docs/source/unstructured.rst
+++ b/docs/source/unstructured.rst
@@ -22,9 +22,6 @@ netCDF and NumPy arrays of unstructured data.
 
 ::
 
-   import cfplot as cfp
-   import cf
-
    f = cf.read("cfplot_data/lfric_initial.nc")
 
    # Select the relevant fields for the objects required for the plot,
@@ -50,9 +47,6 @@ Here we identify the fields in the data that have the longitudes and latitudes f
    :scale: 52%
 
 ::
-
-   import cfplot as cfp
-   import cf
 
    f = cf.read("cfplot_data/lfric_initial.nc")
 
@@ -81,12 +75,12 @@ Here the projection is changed to show the north pole.
 
 ::
 
-   import cf
-   import cfplot as cfp
-   f=cf.read('cfplot_data/lfric_initial.nc')[33]
-   g=f[0,:]
+   f = cf.read("cfplot_data/lfric_initial.nc")
+   pot = f.select_by_identity("air_potential_temperature")[0]
 
-   cfp.con(g, lines=False )
+   g = pot[0, :]
+   cfp.con(g, lines=False)
+
 
 The data in the field has auxiliary longitudes and latitudes that can be contoured as normal.  Internally in cf-plot this is made using the Matplotlib tricontourf command as the data points are spatially irregular.
 
@@ -99,12 +93,12 @@ Orca2 grid
 
 ::
 
-   import cf
    import cfplot as cfp
+   import cf
    import numpy as np
    from netCDF4 import Dataset as ncfile
 
-   #Get an Orca grid and flatten the arrays
+   # Get an Orca grid and flatten the arrays
    nc = ncfile('cfplot_data/orca2.nc')
    lons=np.array(nc.variables['longitude'])
    lats=np.array(nc.variables['latitude'])

--- a/docs/source/unstructured.rst
+++ b/docs/source/unstructured.rst
@@ -93,21 +93,19 @@ Orca2 grid
 
 ::
 
-   import cfplot as cfp
-   import cf
-   import numpy as np
-   from netCDF4 import Dataset as ncfile
+   f = cf.read("cfplot_data/orca2.nc")
 
    # Get an Orca grid and flatten the arrays
-   nc = ncfile('cfplot_data/orca2.nc')
-   lons=np.array(nc.variables['longitude'])
-   lats=np.array(nc.variables['latitude'])
-   temp=np.array(nc.variables['sst'])
-   lons=lons.flatten()
-   lats=lats.flatten()
-   temp=temp.flatten()
+   lons = f.select_by_identity("ncvar%longitude")[0]
+   lats = f.select_by_identity("ncvar%latitude")[0]
+   temp = f.select_by_identity("ncvar%sst")[0]
 
+   lons.flatten(inplace=True)
+   lats.flatten(inplace=True)
+   temp.flatten(inplace=True)
+   
    cfp.con(x=lons, y=lats, f=temp, ptype=1)
+
 
 
 The ORCA2 grid is an ocean grid with missing values over the land points.  The data in this file is from before the UGRID convention was started and has no face connectivity or corner coordinates.  In this case we can only plot a normal contour plot.

--- a/docs/source/unstructured.rst
+++ b/docs/source/unstructured.rst
@@ -22,14 +22,20 @@ netCDF and NumPy arrays of unstructured data.
 
 ::
 
-   import cf
    import cfplot as cfp
-   f=cf.read('cfplot_data/lfric_initial.nc')
+   import cf
 
-   pot=f[33][4,:]
-   lons = f[12]
-   lats = f[13]
-   faces = f[11]
+   f = cf.read("cfplot_data/lfric_initial.nc")
+
+   # Select the relevant fields for the objects required for the plot,
+   # taking the air potential temperature as a variable to choose to view.
+   pot = f.select_by_identity("air_potential_temperature")[0]
+   lats = f.select_by_identity("latitude")[0]
+   lons = f.select_by_identity("longitude")[0]
+   faces = f.select_by_identity("cf_role=face_edge_connectivity")[0]
+
+   # Reduce the variable to match the shapes
+   pot = pot[4,:]
 
    cfp.levs(240, 310, 5)
 
@@ -45,17 +51,25 @@ Here we identify the fields in the data that have the longitudes and latitudes f
 
 ::
 
-   import cf
    import cfplot as cfp
-   f=cf.read('cfplot_data/lfric_initial.nc')
+   import cf
 
-   pot=f[33][4,:]
-   lons = f[12]
-   lats = f[13]
-   faces = f[11]
+   f = cf.read("cfplot_data/lfric_initial.nc")
+
+   # Select the relevant fields for the objects required for the plot,
+   # taking the air potential temperature as a variable to choose to view.
+   pot = f.select_by_identity("air_potential_temperature")[0]
+   lats = f.select_by_identity("latitude")[0]
+   lons = f.select_by_identity("longitude")[0]
+   faces = f.select_by_identity("cf_role=face_edge_connectivity")[0]
+
+   # Reduce the variable to match the shapes
+   pot = pot[4,:]
 
    cfp.levs(240, 310, 5)
-   cfp.mapset(proj='npstere')
+
+   # This time set the projection to a polar one for a different view
+   cfp.mapset(proj="npstere")
    cfp.con(f=pot, face_lons=lons, face_lats=lats, face_connectivity=faces, lines=False)
 
 


### PR DESCRIPTION
As per title. These code snippets were missed out from the test suite of examples, probably because they were not numbered examples and I only added those on a first pass, so I've added a new test class for unnumbered examples (those named but not assigned a number such as 'Example N' for some N) which I will populate soon.

Follow-on work:

- check for unnumbered examples across the docs and add all of these to the test suite, then ensure they work and coordinate so the precise working versions are documented;
- add reference plots to compare with, the uncomment the `@compare_plot_results` decorators
- investigate two test failures (I fixed up the setup but the final plot still fails though it shouldn't in these cases), one of which seems to be a cf-plot bug.
